### PR TITLE
implement basic SASL authentication capabilities

### DIFF
--- a/include/libsrsirc/irc.h
+++ b/include/libsrsirc/irc.h
@@ -385,6 +385,26 @@ bool irc_set_uname(irc *ctx, const char *uname);
  */
 bool irc_set_fname(irc *ctx, const char *fname);
 
+/** \brief set SASL mechanism and authentication string for the next connection.
+ *
+ * This setting will take effect not before the next call to irc_connect().
+ *
+ * \param ctx   IRC context as obtained by irc_init()
+ * \param mech   The mechanism to use for SASL authentication (e.g., 'PLAIN'). \n
+ *                We do *not* depend on this pointer to remain valid after
+ *                we return, i.e. we do make a copy.
+ * \param msg   The message that will serve as the SASL authentication string
+ *                (e.g., '+' if 'mech' is 'EXTERNAL') \n
+ *                We do *not* depend on this pointer to remain valid after
+ *                we return, i.e. we do make a copy.
+ * \param n   The size of the message (in bytes).
+ *
+ * \return true on success, false on failure (which means we're out of memory).
+ *
+ * In case of failure, the old value is left unchanged.
+ */
+bool irc_set_sasl(irc *ctx, const char *mech, const void *msg, size_t n);
+
 /** \brief set IRC 'nickname' for the next connection.
  *
  * The nickname is the primary means to identify users on IRC.

--- a/libsrsirc/intdefs.h
+++ b/libsrsirc/intdefs.h
@@ -53,7 +53,7 @@ struct readctx {
 
 
 /* protocol message handler function pointers */
-typedef uint8_t (*hnd_fn)(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+typedef uint16_t (*hnd_fn)(irc *ctx, tokarr *msg, size_t nargs, bool logon);
 struct msghnd {
 	char cmd[32];
 	hnd_fn hndfn;

--- a/libsrsirc/intdefs.h
+++ b/libsrsirc/intdefs.h
@@ -114,19 +114,22 @@ struct irc_s {
 	/* These are set by their respective irc_set_*() functions and
 	 * generally changes to these don't take effect before the next
 	 * call to irc_connect() */
-	char *pass;       // Server password set by irc_set_pass()
-	char *nick;       // Nickname set by irc_set_nick()
-	char *uname;      // Username set by irc_set_uname()
-	char *fname;      // Full name set by irc_set_fname()
-	uint8_t conflags; // USER flags for logging on
-	bool serv_con;    // Do we want to be service? irc_set_service_connect()
-	char *serv_dist;  // Service logon information (distribution)
-	long serv_type;   // Service logon information (service type)
-	char *serv_info;  // Service logon information (service info)
-	uint64_t hcto_us; // Overall irc_connect() timeout (0=inf)
-	uint64_t scto_us; // Socket connect() timeout per A/AAAA record (0=inf)
-	bool tracking;    // Do we want chan/user tracking? by irc_set_track()
-	bool dumb;        // Connect only, leave logon sequence to the user
+	char *pass;           // Server password set by irc_set_pass()
+	char *nick;           // Nickname set by irc_set_nick()
+	char *uname;          // Username set by irc_set_uname()
+	char *fname;          // Full name set by irc_set_fname()
+	char *sasl_mech;      // SASL mechanism set by irc_set_sasl()
+	char *sasl_msg;       // SASL auth string set by irc_set_sasl()
+	size_t sasl_msg_len;  // size (in bytes) of the SASL message
+	uint8_t conflags;     // USER flags for logging on
+	bool serv_con;        // Do we want to be service? irc_set_service_connect()
+	char *serv_dist;      // Service logon information (distribution)
+	long serv_type;       // Service logon information (service type)
+	char *serv_info;      // Service logon information (service info)
+	uint64_t hcto_us;     // Overall irc_connect() timeout (0=inf)
+	uint64_t scto_us;     // Socket connect() timeout per A/AAAA record (0=inf)
+	bool tracking;        // Do we want chan/user tracking? by irc_set_track()
+	bool dumb;            // Connect only, leave logon sequence to the user
 
 
 

--- a/libsrsirc/irc.c
+++ b/libsrsirc/irc.c
@@ -280,7 +280,7 @@ irc_connect(irc *ctx)
 		 * seeing 004 or 383 makes us consider ourselves logged on
 		 * note that we do not wait for 005, but we will later
 		 * parse it as we ran across it. */
-		uint8_t flags = lsi_msg_handle(ctx, &msg, true);
+		uint16_t flags = lsi_msg_handle(ctx, &msg, true);
 
 		if (flags & CANT_PROCEED)
 			goto fail;

--- a/libsrsirc/irc.c
+++ b/libsrsirc/irc.c
@@ -49,8 +49,10 @@ irc_init(void)
 	if (!(r = MALLOC(sizeof *r)))
 		goto fail;
 
-	r->pass = r->nick = r->uname = r->fname = r->serv_dist
-	    = r->serv_info = r->lasterr = r->banmsg = NULL;
+	r->pass = r->nick = r->uname = r->fname = r->sasl_mech = r->sasl_msg
+	   = r->serv_dist = r->serv_info = r->lasterr = r->banmsg = NULL;
+
+	r->sasl_msg_len = 0;
 
 	r->msghnds = NULL;
 	r->uprehnds = r->uposthnds = NULL;
@@ -183,6 +185,8 @@ irc_dispose(irc *ctx)
 	free(ctx->nick);
 	free(ctx->uname);
 	free(ctx->fname);
+	free(ctx->sasl_mech);
+	free(ctx->sasl_msg);
 	free(ctx->serv_dist);
 	free(ctx->serv_info);
 	free(ctx->msghnds);
@@ -251,7 +255,9 @@ irc_connect(irc *ctx)
 	STRACPY(ctx->mynick, ctx->nick);
 	tokarr msg;
 
-	bool success = false;
+	bool logged_on = false;
+	bool using_sasl = ctx->sasl_mech && ctx->sasl_msg;
+	bool sasl_authed = false;
 	uint64_t trem = 0;
 	int r;
 	do {
@@ -286,9 +292,12 @@ irc_connect(irc *ctx)
 			goto fail;
 
 		if (flags & LOGON_COMPLETE)
-			success = true;
+			logged_on = true;
 
-	} while (!success);
+		if (flags & SASL_COMPLETE)
+			sasl_authed = true;
+
+	} while (!logged_on || (using_sasl && !sasl_authed));
 
 	N("logged on to IRC");
 	return true;
@@ -354,7 +363,7 @@ send_logon(irc *ctx)
 {
 	if (!lsi_conn_online(ctx->con))
 		return false;
-	char aBuf[256];
+	char aBuf[512];
 	char *pBuf = aBuf;
 	aBuf[0] = '\0';
 	size_t rem = sizeof aBuf;
@@ -365,6 +374,17 @@ send_logon(irc *ctx)
 		if (r > (int)rem)
 			r = rem;
 
+		rem -= r;
+		pBuf += r;
+	}
+
+	if (!rem)
+		return false;
+
+	if (ctx->sasl_mech && ctx->sasl_msg) {
+		r = snprintf(pBuf, rem, "CAP REQ :sasl\r\n");
+		if (r > (int)rem)
+			r = rem;
 		rem -= r;
 		pBuf += r;
 	}

--- a/libsrsirc/irc_getset.c
+++ b/libsrsirc/irc_getset.c
@@ -11,6 +11,9 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <string.h>
+
+#include <platform/base_misc.h>
 
 #include <logger/intlog.h>
 
@@ -258,6 +261,24 @@ bool
 irc_set_fname(irc *ctx, const char *fname)
 {
 	return lsi_com_update_strprop(&ctx->fname, fname);
+}
+
+bool
+irc_set_sasl(irc *ctx, const char *mech, const void *msg, size_t n)
+{
+	if  (!lsi_com_update_strprop(&ctx->sasl_mech, mech))
+		return false;
+
+	if (!(ctx->sasl_msg = MALLOC(n))) {
+		free(ctx->sasl_mech);
+		ctx->sasl_mech = NULL;
+		return false;
+	}
+
+	memcpy(ctx->sasl_msg, msg, n);
+	ctx->sasl_msg_len = n;
+
+	return true;
 }
 
 bool

--- a/libsrsirc/irc_msghnd.c
+++ b/libsrsirc/irc_msghnd.c
@@ -30,7 +30,7 @@
 #include <libsrsirc/util.h>
 
 
-static uint8_t
+static uint16_t
 handle_001(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (nargs < 3 || (!ctx->dumb && !logon))
@@ -50,7 +50,7 @@ handle_001(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_002(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!ctx->dumb && !logon)
@@ -64,7 +64,7 @@ handle_002(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_003(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!ctx->dumb && !logon)
@@ -78,7 +78,7 @@ handle_003(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_004(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (nargs < 7 || (!ctx->dumb && !logon))
@@ -118,7 +118,7 @@ handle_PING(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 
 /* This handles 432, 433, 436 and 437 all of which signal us that
  * we can't have the nickname we wanted */
-static uint8_t
+static uint16_t
 handle_bad_nick(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!logon)
@@ -141,7 +141,7 @@ handle_bad_nick(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return lsi_conn_write(ctx->con, buf) ? 0 : IO_ERR;
 }
 
-static uint8_t
+static uint16_t
 handle_464(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!logon)
@@ -153,7 +153,7 @@ handle_464(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 
 /* Successful service logon.  I guess we don't get to see a 004, but haven't
  * really tried this yet */
-static uint8_t
+static uint16_t
 handle_383(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (nargs < 3 || (!ctx->dumb && !logon))
@@ -174,7 +174,7 @@ handle_383(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return LOGON_COMPLETE;
 }
 
-static uint8_t
+static uint16_t
 handle_484(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	ctx->restricted = true;
@@ -182,7 +182,7 @@ handle_484(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_465(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	ctx->banned = true;
@@ -194,7 +194,7 @@ handle_465(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0; /* well if we are, the server will sure disconnect us */
 }
 
-static uint8_t
+static uint16_t
 handle_466(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	W("we will be banned");
@@ -202,7 +202,7 @@ handle_466(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0; /* so what, bitch? */
 }
 
-static uint8_t
+static uint16_t
 handle_ERROR(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	free(ctx->lasterr);
@@ -213,7 +213,7 @@ handle_ERROR(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (nargs < 3 || !(*msg)[0])
@@ -231,7 +231,7 @@ handle_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 }
 
 /* Deals only wih user modes */
-static uint8_t
+static uint16_t
 handle_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (nargs < 4)
@@ -271,7 +271,7 @@ handle_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 }
 
 
-static uint8_t
+static uint16_t
 handle_005_CASEMAPPING(irc *ctx, const char *val)
 {
 	if (lsi_b_strcasecmp(val, "ascii") == 0)
@@ -287,7 +287,7 @@ handle_005_CASEMAPPING(irc *ctx, const char *val)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_005_PREFIX(irc *ctx, const char *val)
 {
 	char str[32];
@@ -311,7 +311,7 @@ handle_005_PREFIX(irc *ctx, const char *val)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_005_CHANMODES(irc *ctx, const char *val)
 {
 	for (int z = 0; z < 4; ++z)
@@ -335,17 +335,17 @@ handle_005_CHANMODES(irc *ctx, const char *val)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_005_CHANTYPES(irc *ctx, const char *val)
 {
 	lsi_b_strNcpy(ctx->m005chantypes, val, MAX_005_CHTYP);
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 handle_005(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
-	uint8_t ret = 0;
+	uint16_t ret = 0;
 	bool have_casemap = false;
 	D("handing a 005 with %zu args", nargs);
 

--- a/libsrsirc/irc_msghnd.c
+++ b/libsrsirc/irc_msghnd.c
@@ -99,7 +99,67 @@ handle_004(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return LOGON_COMPLETE;
 }
 
-static uint8_t
+static uint16_t
+handle_903(irc *ctx, tokarr *msg, size_t nargs, bool logon)
+{
+	if ((!ctx->dumb && !logon) || (!(ctx->sasl_mech && ctx->sasl_msg)))
+		return PROTO_ERR;
+
+	V("Handling a 903");
+
+	return lsi_conn_write(ctx->con, "CAP END\r\n") ? SASL_COMPLETE : IO_ERR;
+}
+
+static uint16_t
+handle_904(irc *ctx, tokarr *msg, size_t nargs, bool logon)
+{
+	if ((!ctx->dumb && !logon) || (!(ctx->sasl_mech && ctx->sasl_msg)))
+		return PROTO_ERR;
+
+	V("Handling a 904");
+
+	return SASL_ERR;
+}
+
+static uint16_t
+handle_CAP(irc *ctx, tokarr *msg, size_t nargs, bool logon)
+{
+	V("Handling a CAP");
+
+	if (nargs != 5 || strncmp((*msg)[4], "sasl", 4))
+		return 0;
+
+	if ((!ctx->dumb && !logon) || (!(ctx->sasl_mech && ctx->sasl_msg)))
+		return PROTO_ERR;
+
+	if (!strcmp((*msg)[3], "ACK")) {
+		char buf[256];
+		snprintf(buf, sizeof buf, "AUTHENTICATE %s\r\n", ctx->sasl_mech);
+		return lsi_conn_write(ctx->con, buf) ? 0 : IO_ERR;
+	} else if (!strcmp((*msg)[3], "NAK")) {
+		return NO_SASL;
+	}
+
+	return 0;
+}
+
+static uint16_t
+handle_AUTHENTICATE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
+{
+	if (nargs != 3 || strcmp((*msg)[2], "+"))
+		return 0;
+
+	if ((!ctx->dumb && !logon) || (!(ctx->sasl_mech && ctx->sasl_msg)))
+		return PROTO_ERR;
+
+	char buf[256];
+	snprintf(buf, sizeof buf, "AUTHENTICATE %.*s\r\n",
+           (int) ctx->sasl_msg_len, ctx->sasl_msg);
+
+	return lsi_conn_write(ctx->con, buf) ? 0 : IO_ERR;
+}
+
+static uint16_t
 handle_PING(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	/* We only handle PINGs at logon. It's the user's job afterwards. */
@@ -411,11 +471,14 @@ lsi_imh_regall(irc *ctx, bool dumb)
 		 * PING and we also don't pay attention to 464 (Wrong server
 		 * password).  This is all left to the user */
 		fail = fail || !lsi_msg_reghnd(ctx, "PING", handle_PING, "core");
+		fail = fail || !lsi_msg_reghnd(ctx, "CAP", handle_CAP, "core");
+		fail = fail || !lsi_msg_reghnd(ctx, "AUTHENTICATE", handle_AUTHENTICATE, "core");
 		fail = fail || !lsi_msg_reghnd(ctx, "432", handle_bad_nick, "core");
 		fail = fail || !lsi_msg_reghnd(ctx, "433", handle_bad_nick, "core");
 		fail = fail || !lsi_msg_reghnd(ctx, "436", handle_bad_nick, "core");
 		fail = fail || !lsi_msg_reghnd(ctx, "437", handle_bad_nick, "core");
 		fail = fail || !lsi_msg_reghnd(ctx, "464", handle_464, "core");
+		fail = fail || !lsi_msg_reghnd(ctx, "903", handle_903, "core");
 	}
 
 	fail = fail || !lsi_msg_reghnd(ctx, "NICK", handle_NICK, "core");

--- a/libsrsirc/irc_track.c
+++ b/libsrsirc/irc_track.c
@@ -29,22 +29,22 @@
 #include "ucbase.h"
 #include "irc_track_int.h"
 
-static uint8_t h_JOIN(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_311(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_332(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_333(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_352(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_353(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_366(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_PART(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_QUIT(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_KICK(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_PRIVMSG(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_NOTICE(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_324(irc *ctx, tokarr *msg, size_t nargs, bool logon);
-static uint8_t h_TOPIC(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_JOIN(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_311(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_332(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_333(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_352(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_353(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_366(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_PART(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_QUIT(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_KICK(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_PRIVMSG(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_NOTICE(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_324(irc *ctx, tokarr *msg, size_t nargs, bool logon);
+static uint16_t h_TOPIC(irc *ctx, tokarr *msg, size_t nargs, bool logon);
 
 bool
 lsi_trk_init(irc *ctx)
@@ -85,7 +85,7 @@ lsi_trk_deinit(irc *ctx)
 }
 
 
-static uint8_t
+static uint16_t
 h_JOIN(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 3)
@@ -133,7 +133,7 @@ h_JOIN(irc *ctx, tokarr *msg, size_t nargs, bool logon)
  */
 
 /*:rajaniemi.freenode.net 352 nvmme CHAN UNAME HOST SRV NICK H :0 irc netcat*/
-static uint8_t
+static uint16_t
 h_352(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 10)
@@ -175,10 +175,10 @@ h_352(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 }
 
 /*:rajaniemi.freenode.net 315 nvmme #fstd :End of /WHO list.*/
-//static uint8_t
+//static uint16_t
 //h_315(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 
-static uint8_t
+static uint16_t
 h_332(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 5)
@@ -196,7 +196,7 @@ h_332(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_333(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 6)
@@ -216,7 +216,7 @@ h_333(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_353(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 6)
@@ -273,7 +273,7 @@ h_353(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_366(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -291,7 +291,7 @@ h_366(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_PART(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 3)
@@ -318,7 +318,7 @@ h_PART(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_QUIT(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0])
@@ -333,7 +333,7 @@ h_QUIT(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_KICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -357,10 +357,10 @@ h_KICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
-	uint8_t res = 0;
+	uint16_t res = 0;
 
 	if (!(*msg)[0] || nargs < 3)
 		return PROTO_ERR;
@@ -376,7 +376,7 @@ h_NICK(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return res;
 }
 
-static uint8_t
+static uint16_t
 h_TOPIC(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -401,10 +401,10 @@ h_TOPIC(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_MODE_chanmode(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
-	uint8_t res = 0;
+	uint16_t res = 0;
 
 	if (!(*msg)[0] || nargs < 4)
 		return PROTO_ERR;
@@ -449,7 +449,7 @@ h_MODE_chanmode(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return res;
 }
 
-static uint8_t
+static uint16_t
 h_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -463,7 +463,7 @@ h_MODE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_PRIVMSG(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -478,7 +478,7 @@ h_PRIVMSG(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 	return 0;
 }
 
-static uint8_t
+static uint16_t
 h_NOTICE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 4)
@@ -494,13 +494,13 @@ h_NOTICE(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 }
 
 
-static uint8_t
+static uint16_t
 h_324(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 5)
 		return PROTO_ERR;
 
-	uint8_t res = 0;
+	uint16_t res = 0;
 
 	chan *c = lsi_ucb_get_chan(ctx, (*msg)[3], true);
 	if (!c) {
@@ -536,7 +536,7 @@ h_324(irc *ctx, tokarr *msg, size_t nargs, bool logon)
  * ":*1<reply> *( " " <reply> )"
  * reply = nickname [ "*" ] "=" ( "+" / "-" ) hostname
  */
-//static uint8_t
+//static uint16_t
 //h_302(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 //{
 //}
@@ -544,7 +544,7 @@ h_324(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 /* 311    RPL_WHOISUSER
  * "<nick> <user> <host> * :<real name>"
  */
-static uint8_t
+static uint16_t
 h_311(irc *ctx, tokarr *msg, size_t nargs, bool logon)
 {
 	if (!(*msg)[0] || nargs < 8)

--- a/libsrsirc/msg.c
+++ b/libsrsirc/msg.c
@@ -131,10 +131,10 @@ dispatch_uhnd(irc *ctx, tokarr *msg, size_t ac, bool pre)
 	return true;
 }
 
-uint8_t
+uint16_t
 lsi_msg_handle(irc *ctx, tokarr *msg, bool logon)
 {
-	uint8_t res = 0;
+	uint16_t res = 0;
 	size_t i = 0;
 	size_t ac = 2;
 	while (ac < COUNTOF(*msg) && (*msg)[ac])
@@ -166,7 +166,7 @@ lsi_msg_handle(irc *ctx, tokarr *msg, bool logon)
 	return res;
 
 fail:;
-	uint8_t r = res & ~CANT_PROCEED;
+	uint16_t r = res & ~CANT_PROCEED;
 
 	if (r & USER_ERR) {
 		E("user-registered message handler denied proceeding");

--- a/libsrsirc/msg.c
+++ b/libsrsirc/msg.c
@@ -172,6 +172,10 @@ fail:;
 		E("user-registered message handler denied proceeding");
 	} else if (r & AUTH_ERR) {
 		E("failed to authenticate");
+	} else if (r & SASL_ERR) {
+		E("SASL authentication failed");
+	} else if (r & NO_SASL) {
+		E("the server does not support SASL");
 	} else if (r & IO_ERR) {
 		E("i/o error");
 	} else if (r & ALLOC_ERR) {

--- a/libsrsirc/msg.h
+++ b/libsrsirc/msg.h
@@ -21,7 +21,10 @@
 # define IO_ERR        (CANT_PROCEED|(1<<4)) // i/o failure (lsi_conn_write())
 # define ALLOC_ERR     (CANT_PROCEED|(1<<5)) // out of memory
 # define USER_ERR      (CANT_PROCEED|(1<<6)) // user msg handler failed
-#define LOGON_COMPLETE (1<<7) // we now consider ourselves logged on
+# define SASL_ERR      (CANT_PROCEED|(1<<7)) // SASL authentication failed
+# define NO_SASL       (CANT_PROCEED|(1<<8)) // the server doesn't support SASL
+#define LOGON_COMPLETE (1<<9) // we now consider ourselves logged on
+#define SASL_COMPLETE  (1<<10) // SASL authentication succeeded
 
 bool lsi_msg_reghnd(irc *ctx, const char *cmd, hnd_fn hndfn, const char *module);
 void lsi_msg_unregall(irc *ctx, const char *module);

--- a/libsrsirc/msg.h
+++ b/libsrsirc/msg.h
@@ -31,7 +31,7 @@ bool lsi_msg_reguhnd(irc *ctx, const char *cmd, uhnd_fn hndfn, bool pre);
 
 /* returns the bitwise OR of one or more of the above
  * bitmasks, or 0 for nothing special */
-uint8_t lsi_msg_handle(irc *ctx, tokarr *msg, bool logon);
+uint16_t lsi_msg_handle(irc *ctx, tokarr *msg, bool logon);
 
 
 #endif /* LIBSRSIRC_IMSG_H */


### PR DESCRIPTION
adds the function

```c
irc_set_sasl(irc *ctx, char const *mechanism, char const *message)
```

which allows the user to authenticate using SASL if the server supports it