### PR TITLE
linting: fix "protcol" spelling errors

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Interface documentation: http://penenen.de/libsrsirc/doxygen/modules.html
 Some highlights:
 ----------------
   - Lightweight:  libsrsirc is small and uses very little resources; most of
-                  the protcol handling is essentially zero-copy.  It does not
+                  the protocol handling is essentially zero-copy.  It does not
                   try to offer every conceivable feature an IRC lib could
                   possibly have, if the costs would outweight the gains.
                   This allows creating thousands of independent instances.

--- a/include/libsrsirc/defs.h
+++ b/include/libsrsirc/defs.h
@@ -168,7 +168,7 @@ typedef struct irc_s irc;
  *
  * In other words, tok[1] will *always* be the "command" part of the message.
  *
- * RFC1459/2812 specify that a protcol message may consist of up to 17 fields;
+ * RFC1459/2812 specify that a protocol message may consist of up to 17 fields;
  * we have room for one more to guarantee a NULL sentinel after the last one
  */
 typedef char *tokarr[18];


### PR DESCRIPTION
Credit to @smujohnson for finding.

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>